### PR TITLE
Add animated halftone profile portrait

### DIFF
--- a/assets/scripts/profile-halftone.js
+++ b/assets/scripts/profile-halftone.js
@@ -9,10 +9,26 @@
   const BREATH_DURATION = 5600;
   const BREATH_STRENGTH = 0.012;
   const WAVE_DURATION = 8200;
-  const WAVE_BANDWIDTH = 0.17;
-  const WAVE_RIPPLE_WIDTH = 0.055;
-  const WAVE_STRENGTH = 0.08;
-  const COLOR_BANDWIDTH = 0.2;
+  const WAVE_BANDWIDTH = 0.075;
+  const WAVE_MAX_SCALE = 2;
+  const WAVE_VISIBILITY_THRESHOLD = 0.012;
+
+  const parseHexColor = (value) => {
+    const raw = value.replace("#", "").trim();
+    const hex = raw.length === 3
+      ? raw.split("").map((character) => character + character).join("")
+      : raw;
+
+    if (!/^[0-9a-f]{6}$/i.test(hex)) {
+      return [85, 203, 211];
+    }
+
+    return [
+      parseInt(hex.slice(0, 2), 16),
+      parseInt(hex.slice(2, 4), 16),
+      parseInt(hex.slice(4, 6), 16)
+    ];
+  };
 
   const drawHalftone = (portrait) => {
     const image = portrait.querySelector(".home-halftone__source");
@@ -30,12 +46,8 @@
     const sampleCanvas = document.createElement("canvas");
     const sampleContext = sampleCanvas.getContext("2d", { willReadFrequently: true });
     const context = canvas.getContext("2d");
-    const colorCanvas = document.createElement("canvas");
-    const colorContext = colorCanvas.getContext("2d");
-    const waveCanvas = document.createElement("canvas");
-    const waveContext = waveCanvas.getContext("2d");
 
-    if (!sampleContext || !context || !colorContext || !waveContext) {
+    if (!sampleContext || !context) {
       return;
     }
 
@@ -43,18 +55,14 @@
     canvas.height = height;
     sampleCanvas.width = width;
     sampleCanvas.height = height;
-    colorCanvas.width = width;
-    colorCanvas.height = height;
-    waveCanvas.width = width;
-    waveCanvas.height = height;
     sampleContext.drawImage(image, 0, 0, width, height);
 
     const pixels = sampleContext.getImageData(0, 0, width, height).data;
     const dotColor = portrait.dataset.dotColor || "#55cbd3";
+    const dotColorRgb = parseHexColor(dotColor);
     const diagonalLengthSquared = width * width + height * height;
     const dots = [];
 
-    colorContext.clearRect(0, 0, width, height);
     let row = 0;
 
     for (let y = DOT_SPACING / 2; y < height; y += DOT_SPACING) {
@@ -80,58 +88,26 @@
 
         dots.push({
           alpha: alpha * (0.62 + tone * 0.38),
+          blue: pixels[offset + 2],
           diagonal: (x * width + y * height) / diagonalLengthSquared,
+          green: pixels[offset + 1],
           radius,
+          red: pixels[offset],
+          scale: 1,
+          wave: 0,
           x,
           y
         });
-
-        colorContext.globalAlpha = alpha * (0.62 + tone * 0.38);
-        colorContext.fillStyle = `rgb(${pixels[offset]}, ${pixels[offset + 1]}, ${pixels[offset + 2]})`;
-        colorContext.beginPath();
-        colorContext.arc(x, y, radius, 0, Math.PI * 2);
-        colorContext.fill();
       }
 
       row += 1;
     }
-
-    colorContext.globalAlpha = 1;
 
     const startedAt = performance.now();
     const motionPreference = window.matchMedia("(prefers-reduced-motion: reduce)");
     let animationFrame = null;
     let isVisible = true;
     let lastFrameAt = 0;
-
-    const drawColorWave = (wavePosition) => {
-      waveContext.clearRect(0, 0, width, height);
-      waveContext.globalCompositeOperation = "source-over";
-      waveContext.drawImage(colorCanvas, 0, 0);
-      waveContext.globalCompositeOperation = "destination-in";
-
-      const gradient = waveContext.createLinearGradient(
-        (wavePosition - COLOR_BANDWIDTH) * width,
-        (wavePosition - COLOR_BANDWIDTH) * height,
-        (wavePosition + COLOR_BANDWIDTH) * width,
-        (wavePosition + COLOR_BANDWIDTH) * height
-      );
-
-      gradient.addColorStop(0, "rgba(255, 255, 255, 0)");
-      gradient.addColorStop(0.12, "rgba(255, 255, 255, 0.08)");
-      gradient.addColorStop(0.25, "rgba(255, 255, 255, 0.52)");
-      gradient.addColorStop(0.38, "rgba(255, 255, 255, 0.18)");
-      gradient.addColorStop(0.5, "rgba(255, 255, 255, 0.88)");
-      gradient.addColorStop(0.62, "rgba(255, 255, 255, 0.18)");
-      gradient.addColorStop(0.75, "rgba(255, 255, 255, 0.48)");
-      gradient.addColorStop(0.88, "rgba(255, 255, 255, 0.08)");
-      gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
-
-      waveContext.fillStyle = gradient;
-      waveContext.fillRect(0, 0, width, height);
-      waveContext.globalCompositeOperation = "source-over";
-      context.drawImage(waveCanvas, 0, 0);
-    };
 
     const drawFrame = (now, animate) => {
       const elapsed = now - startedAt;
@@ -146,27 +122,42 @@
       context.fillStyle = dotColor;
 
       dots.forEach((dot) => {
-        let scale = breath;
+        const distance = dot.diagonal - wavePosition;
+        const wave = animate
+          ? Math.exp(-0.5 * Math.pow(distance / WAVE_BANDWIDTH, 2))
+          : 0;
+        const easedWave = wave * wave * (3 - 2 * wave);
 
-        if (animate) {
-          const distance = dot.diagonal - wavePosition;
-          const envelope = Math.exp(-0.5 * Math.pow(distance / WAVE_BANDWIDTH, 2));
-          const ripple = Math.cos(distance / WAVE_RIPPLE_WIDTH * Math.PI);
+        dot.wave = easedWave;
+        dot.scale = breath + (WAVE_MAX_SCALE - breath) * easedWave;
 
-          scale += envelope * ripple * WAVE_STRENGTH;
+        if (easedWave >= WAVE_VISIBILITY_THRESHOLD) {
+          return;
         }
 
         context.globalAlpha = dot.alpha;
         context.beginPath();
-        context.arc(dot.x, dot.y, dot.radius * scale, 0, Math.PI * 2);
+        context.arc(dot.x, dot.y, dot.radius * dot.scale, 0, Math.PI * 2);
+        context.fill();
+      });
+
+      dots.forEach((dot) => {
+        if (dot.wave < WAVE_VISIBILITY_THRESHOLD) {
+          return;
+        }
+
+        const red = Math.round(dotColorRgb[0] + (dot.red - dotColorRgb[0]) * dot.wave);
+        const green = Math.round(dotColorRgb[1] + (dot.green - dotColorRgb[1]) * dot.wave);
+        const blue = Math.round(dotColorRgb[2] + (dot.blue - dotColorRgb[2]) * dot.wave);
+
+        context.fillStyle = `rgb(${red}, ${green}, ${blue})`;
+        context.globalAlpha = dot.alpha;
+        context.beginPath();
+        context.arc(dot.x, dot.y, dot.radius * dot.scale, 0, Math.PI * 2);
         context.fill();
       });
 
       context.globalAlpha = 1;
-
-      if (animate) {
-        drawColorWave(wavePosition);
-      }
     };
 
     const stop = () => {

--- a/assets/scripts/profile-halftone.js
+++ b/assets/scripts/profile-halftone.js
@@ -3,6 +3,16 @@
 
   const MAX_RENDER_WIDTH = 960;
   const DOT_SPACING = 10;
+  const DOT_RADIUS_BASE = 0.085;
+  const DOT_RADIUS_TONE = 0.315;
+  const FRAME_INTERVAL = 1000 / 30;
+  const BREATH_DURATION = 5600;
+  const BREATH_STRENGTH = 0.012;
+  const WAVE_DURATION = 8200;
+  const WAVE_BANDWIDTH = 0.17;
+  const WAVE_RIPPLE_WIDTH = 0.055;
+  const WAVE_STRENGTH = 0.08;
+  const COLOR_BANDWIDTH = 0.2;
 
   const drawHalftone = (portrait) => {
     const image = portrait.querySelector(".home-halftone__source");
@@ -12,13 +22,20 @@
       return;
     }
 
-    const width = Math.min(MAX_RENDER_WIDTH, image.naturalWidth);
+    const renderedWidth = image.getBoundingClientRect().width;
+    const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+    const preferredWidth = Math.max(640, Math.round(renderedWidth * pixelRatio));
+    const width = Math.min(MAX_RENDER_WIDTH, image.naturalWidth, preferredWidth);
     const height = Math.round(width * image.naturalHeight / image.naturalWidth);
     const sampleCanvas = document.createElement("canvas");
     const sampleContext = sampleCanvas.getContext("2d", { willReadFrequently: true });
     const context = canvas.getContext("2d");
+    const colorCanvas = document.createElement("canvas");
+    const colorContext = colorCanvas.getContext("2d");
+    const waveCanvas = document.createElement("canvas");
+    const waveContext = waveCanvas.getContext("2d");
 
-    if (!sampleContext || !context) {
+    if (!sampleContext || !context || !colorContext || !waveContext) {
       return;
     }
 
@@ -26,14 +43,18 @@
     canvas.height = height;
     sampleCanvas.width = width;
     sampleCanvas.height = height;
+    colorCanvas.width = width;
+    colorCanvas.height = height;
+    waveCanvas.width = width;
+    waveCanvas.height = height;
     sampleContext.drawImage(image, 0, 0, width, height);
 
     const pixels = sampleContext.getImageData(0, 0, width, height).data;
     const dotColor = portrait.dataset.dotColor || "#55cbd3";
+    const diagonalLengthSquared = width * width + height * height;
+    const dots = [];
 
-    context.clearRect(0, 0, width, height);
-    context.fillStyle = dotColor;
-
+    colorContext.clearRect(0, 0, width, height);
     let row = 0;
 
     for (let y = DOT_SPACING / 2; y < height; y += DOT_SPACING) {
@@ -55,19 +76,157 @@
           pixels[offset + 2] * 0.0722
         ) / 255;
         const tone = Math.pow(luminance, 0.9);
-        const radius = DOT_SPACING * (0.09 + tone * 0.35) * Math.sqrt(alpha);
+        const radius = DOT_SPACING * (DOT_RADIUS_BASE + tone * DOT_RADIUS_TONE) * Math.sqrt(alpha);
 
-        context.globalAlpha = alpha * (0.62 + tone * 0.38);
-        context.beginPath();
-        context.arc(x, y, radius, 0, Math.PI * 2);
-        context.fill();
+        dots.push({
+          alpha: alpha * (0.62 + tone * 0.38),
+          diagonal: (x * width + y * height) / diagonalLengthSquared,
+          radius,
+          x,
+          y
+        });
+
+        colorContext.globalAlpha = alpha * (0.62 + tone * 0.38);
+        colorContext.fillStyle = `rgb(${pixels[offset]}, ${pixels[offset + 1]}, ${pixels[offset + 2]})`;
+        colorContext.beginPath();
+        colorContext.arc(x, y, radius, 0, Math.PI * 2);
+        colorContext.fill();
       }
 
       row += 1;
     }
 
-    context.globalAlpha = 1;
+    colorContext.globalAlpha = 1;
+
+    const startedAt = performance.now();
+    const motionPreference = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let animationFrame = null;
+    let isVisible = true;
+    let lastFrameAt = 0;
+
+    const drawColorWave = (wavePosition) => {
+      waveContext.clearRect(0, 0, width, height);
+      waveContext.globalCompositeOperation = "source-over";
+      waveContext.drawImage(colorCanvas, 0, 0);
+      waveContext.globalCompositeOperation = "destination-in";
+
+      const gradient = waveContext.createLinearGradient(
+        (wavePosition - COLOR_BANDWIDTH) * width,
+        (wavePosition - COLOR_BANDWIDTH) * height,
+        (wavePosition + COLOR_BANDWIDTH) * width,
+        (wavePosition + COLOR_BANDWIDTH) * height
+      );
+
+      gradient.addColorStop(0, "rgba(255, 255, 255, 0)");
+      gradient.addColorStop(0.12, "rgba(255, 255, 255, 0.08)");
+      gradient.addColorStop(0.25, "rgba(255, 255, 255, 0.52)");
+      gradient.addColorStop(0.38, "rgba(255, 255, 255, 0.18)");
+      gradient.addColorStop(0.5, "rgba(255, 255, 255, 0.88)");
+      gradient.addColorStop(0.62, "rgba(255, 255, 255, 0.18)");
+      gradient.addColorStop(0.75, "rgba(255, 255, 255, 0.48)");
+      gradient.addColorStop(0.88, "rgba(255, 255, 255, 0.08)");
+      gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
+
+      waveContext.fillStyle = gradient;
+      waveContext.fillRect(0, 0, width, height);
+      waveContext.globalCompositeOperation = "source-over";
+      context.drawImage(waveCanvas, 0, 0);
+    };
+
+    const drawFrame = (now, animate) => {
+      const elapsed = now - startedAt;
+      const breath = animate
+        ? 1 + Math.sin(elapsed / BREATH_DURATION * Math.PI * 2) * BREATH_STRENGTH
+        : 1;
+      const wavePosition = animate
+        ? (elapsed % WAVE_DURATION) / WAVE_DURATION * 1.5 - 0.25
+        : -1;
+
+      context.clearRect(0, 0, width, height);
+      context.fillStyle = dotColor;
+
+      dots.forEach((dot) => {
+        let scale = breath;
+
+        if (animate) {
+          const distance = dot.diagonal - wavePosition;
+          const envelope = Math.exp(-0.5 * Math.pow(distance / WAVE_BANDWIDTH, 2));
+          const ripple = Math.cos(distance / WAVE_RIPPLE_WIDTH * Math.PI);
+
+          scale += envelope * ripple * WAVE_STRENGTH;
+        }
+
+        context.globalAlpha = dot.alpha;
+        context.beginPath();
+        context.arc(dot.x, dot.y, dot.radius * scale, 0, Math.PI * 2);
+        context.fill();
+      });
+
+      context.globalAlpha = 1;
+
+      if (animate) {
+        drawColorWave(wavePosition);
+      }
+    };
+
+    const stop = () => {
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame);
+        animationFrame = null;
+      }
+    };
+
+    const tick = (now) => {
+      animationFrame = null;
+
+      if (!isVisible || motionPreference.matches) {
+        return;
+      }
+
+      if (now - lastFrameAt >= FRAME_INTERVAL) {
+        drawFrame(now, true);
+        lastFrameAt = now;
+      }
+
+      animationFrame = requestAnimationFrame(tick);
+    };
+
+    const start = () => {
+      if (animationFrame === null && isVisible && !motionPreference.matches) {
+        animationFrame = requestAnimationFrame(tick);
+      }
+    };
+
+    const handleMotionPreference = () => {
+      stop();
+      drawFrame(performance.now(), false);
+      start();
+    };
+
+    drawFrame(performance.now(), false);
     portrait.classList.add("is-rendered");
+
+    if ("IntersectionObserver" in window) {
+      const observer = new IntersectionObserver(([entry]) => {
+        isVisible = entry.isIntersecting;
+
+        if (isVisible) {
+          start();
+        } else {
+          stop();
+        }
+      }, { rootMargin: "100px" });
+
+      observer.observe(portrait);
+    }
+
+    if (typeof motionPreference.addEventListener === "function") {
+      motionPreference.addEventListener("change", handleMotionPreference);
+    } else if (typeof motionPreference.addListener === "function") {
+      motionPreference.addListener(handleMotionPreference);
+    }
+
+    start();
   };
 
   document.querySelectorAll("[data-halftone-portrait]").forEach((portrait) => {

--- a/assets/scripts/profile-halftone.js
+++ b/assets/scripts/profile-halftone.js
@@ -1,0 +1,86 @@
+(() => {
+  "use strict";
+
+  const MAX_RENDER_WIDTH = 960;
+  const DOT_SPACING = 10;
+
+  const drawHalftone = (portrait) => {
+    const image = portrait.querySelector(".home-halftone__source");
+    const canvas = portrait.querySelector(".home-halftone__canvas");
+
+    if (!image || !canvas || !image.naturalWidth || !image.naturalHeight) {
+      return;
+    }
+
+    const width = Math.min(MAX_RENDER_WIDTH, image.naturalWidth);
+    const height = Math.round(width * image.naturalHeight / image.naturalWidth);
+    const sampleCanvas = document.createElement("canvas");
+    const sampleContext = sampleCanvas.getContext("2d", { willReadFrequently: true });
+    const context = canvas.getContext("2d");
+
+    if (!sampleContext || !context) {
+      return;
+    }
+
+    canvas.width = width;
+    canvas.height = height;
+    sampleCanvas.width = width;
+    sampleCanvas.height = height;
+    sampleContext.drawImage(image, 0, 0, width, height);
+
+    const pixels = sampleContext.getImageData(0, 0, width, height).data;
+    const dotColor = portrait.dataset.dotColor || "#55cbd3";
+
+    context.clearRect(0, 0, width, height);
+    context.fillStyle = dotColor;
+
+    let row = 0;
+
+    for (let y = DOT_SPACING / 2; y < height; y += DOT_SPACING) {
+      const rowOffset = row % 2 === 0 ? 0 : DOT_SPACING / 2;
+
+      for (let x = DOT_SPACING / 2 + rowOffset; x < width; x += DOT_SPACING) {
+        const sampleX = Math.min(width - 1, Math.round(x));
+        const sampleY = Math.min(height - 1, Math.round(y));
+        const offset = (sampleY * width + sampleX) * 4;
+        const alpha = pixels[offset + 3] / 255;
+
+        if (alpha < 0.08) {
+          continue;
+        }
+
+        const luminance = (
+          pixels[offset] * 0.2126 +
+          pixels[offset + 1] * 0.7152 +
+          pixels[offset + 2] * 0.0722
+        ) / 255;
+        const tone = Math.pow(luminance, 0.9);
+        const radius = DOT_SPACING * (0.09 + tone * 0.35) * Math.sqrt(alpha);
+
+        context.globalAlpha = alpha * (0.62 + tone * 0.38);
+        context.beginPath();
+        context.arc(x, y, radius, 0, Math.PI * 2);
+        context.fill();
+      }
+
+      row += 1;
+    }
+
+    context.globalAlpha = 1;
+    portrait.classList.add("is-rendered");
+  };
+
+  document.querySelectorAll("[data-halftone-portrait]").forEach((portrait) => {
+    const image = portrait.querySelector(".home-halftone__source");
+
+    if (!image) {
+      return;
+    }
+
+    if (image.complete) {
+      drawHalftone(portrait);
+    } else {
+      image.addEventListener("load", () => drawHalftone(portrait), { once: true });
+    }
+  });
+})();

--- a/assets/scripts/profile-halftone.js
+++ b/assets/scripts/profile-halftone.js
@@ -8,27 +8,12 @@
   const FRAME_INTERVAL = 1000 / 30;
   const BREATH_DURATION = 5600;
   const BREATH_STRENGTH = 0.012;
-  const WAVE_DURATION = 8200;
-  const WAVE_BANDWIDTH = 0.075;
+  const WAVE_SWEEP_DURATION = 11000;
+  const WAVE_PAUSE_DURATION = 8000;
+  const WAVE_CYCLE_DURATION = WAVE_SWEEP_DURATION + WAVE_PAUSE_DURATION;
+  const WAVE_BANDWIDTH = 0.068;
   const WAVE_MAX_SCALE = 2;
-  const WAVE_VISIBILITY_THRESHOLD = 0.012;
-
-  const parseHexColor = (value) => {
-    const raw = value.replace("#", "").trim();
-    const hex = raw.length === 3
-      ? raw.split("").map((character) => character + character).join("")
-      : raw;
-
-    if (!/^[0-9a-f]{6}$/i.test(hex)) {
-      return [85, 203, 211];
-    }
-
-    return [
-      parseInt(hex.slice(0, 2), 16),
-      parseInt(hex.slice(2, 4), 16),
-      parseInt(hex.slice(4, 6), 16)
-    ];
-  };
+  const COLOR_REVEAL_EXTENT = 2.5;
 
   const drawHalftone = (portrait) => {
     const image = portrait.querySelector(".home-halftone__source");
@@ -46,8 +31,10 @@
     const sampleCanvas = document.createElement("canvas");
     const sampleContext = sampleCanvas.getContext("2d", { willReadFrequently: true });
     const context = canvas.getContext("2d");
+    const waveCanvas = document.createElement("canvas");
+    const waveContext = waveCanvas.getContext("2d");
 
-    if (!sampleContext || !context) {
+    if (!sampleContext || !context || !waveContext) {
       return;
     }
 
@@ -55,11 +42,12 @@
     canvas.height = height;
     sampleCanvas.width = width;
     sampleCanvas.height = height;
+    waveCanvas.width = width;
+    waveCanvas.height = height;
     sampleContext.drawImage(image, 0, 0, width, height);
 
     const pixels = sampleContext.getImageData(0, 0, width, height).data;
     const dotColor = portrait.dataset.dotColor || "#55cbd3";
-    const dotColorRgb = parseHexColor(dotColor);
     const diagonalLengthSquared = width * width + height * height;
     const dots = [];
 
@@ -88,13 +76,9 @@
 
         dots.push({
           alpha: alpha * (0.62 + tone * 0.38),
-          blue: pixels[offset + 2],
           diagonal: (x * width + y * height) / diagonalLengthSquared,
-          green: pixels[offset + 1],
           radius,
-          red: pixels[offset],
           scale: 1,
-          wave: 0,
           x,
           y
         });
@@ -109,13 +93,48 @@
     let isVisible = true;
     let lastFrameAt = 0;
 
+    const drawPhotoWave = (wavePosition) => {
+      const revealWidth = WAVE_BANDWIDTH * COLOR_REVEAL_EXTENT;
+
+      waveContext.clearRect(0, 0, width, height);
+      waveContext.globalCompositeOperation = "source-over";
+      waveContext.drawImage(sampleCanvas, 0, 0);
+      waveContext.globalCompositeOperation = "destination-in";
+
+      const gradient = waveContext.createLinearGradient(
+        (wavePosition - revealWidth) * width,
+        (wavePosition - revealWidth) * height,
+        (wavePosition + revealWidth) * width,
+        (wavePosition + revealWidth) * height
+      );
+
+      gradient.addColorStop(0, "rgba(255, 255, 255, 0)");
+      gradient.addColorStop(0.1, "rgba(255, 255, 255, 0.05)");
+      gradient.addColorStop(0.2, "rgba(255, 255, 255, 0.25)");
+      gradient.addColorStop(0.3, "rgba(255, 255, 255, 0.66)");
+      gradient.addColorStop(0.4, "rgba(255, 255, 255, 0.96)");
+      gradient.addColorStop(0.5, "rgba(255, 255, 255, 1)");
+      gradient.addColorStop(0.6, "rgba(255, 255, 255, 0.96)");
+      gradient.addColorStop(0.7, "rgba(255, 255, 255, 0.66)");
+      gradient.addColorStop(0.8, "rgba(255, 255, 255, 0.25)");
+      gradient.addColorStop(0.9, "rgba(255, 255, 255, 0.05)");
+      gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
+
+      waveContext.fillStyle = gradient;
+      waveContext.fillRect(0, 0, width, height);
+      waveContext.globalCompositeOperation = "source-over";
+      context.drawImage(waveCanvas, 0, 0);
+    };
+
     const drawFrame = (now, animate) => {
       const elapsed = now - startedAt;
       const breath = animate
         ? 1 + Math.sin(elapsed / BREATH_DURATION * Math.PI * 2) * BREATH_STRENGTH
         : 1;
-      const wavePosition = animate
-        ? (elapsed % WAVE_DURATION) / WAVE_DURATION * 1.5 - 0.25
+      const waveElapsed = elapsed % WAVE_CYCLE_DURATION;
+      const waveActive = animate && waveElapsed < WAVE_SWEEP_DURATION;
+      const wavePosition = waveActive
+        ? waveElapsed / WAVE_SWEEP_DURATION * 1.5 - 0.25
         : -1;
 
       context.clearRect(0, 0, width, height);
@@ -123,34 +142,13 @@
 
       dots.forEach((dot) => {
         const distance = dot.diagonal - wavePosition;
-        const wave = animate
+        const wave = waveActive
           ? Math.exp(-0.5 * Math.pow(distance / WAVE_BANDWIDTH, 2))
           : 0;
         const easedWave = wave * wave * (3 - 2 * wave);
 
-        dot.wave = easedWave;
         dot.scale = breath + (WAVE_MAX_SCALE - breath) * easedWave;
 
-        if (easedWave >= WAVE_VISIBILITY_THRESHOLD) {
-          return;
-        }
-
-        context.globalAlpha = dot.alpha;
-        context.beginPath();
-        context.arc(dot.x, dot.y, dot.radius * dot.scale, 0, Math.PI * 2);
-        context.fill();
-      });
-
-      dots.forEach((dot) => {
-        if (dot.wave < WAVE_VISIBILITY_THRESHOLD) {
-          return;
-        }
-
-        const red = Math.round(dotColorRgb[0] + (dot.red - dotColorRgb[0]) * dot.wave);
-        const green = Math.round(dotColorRgb[1] + (dot.green - dotColorRgb[1]) * dot.wave);
-        const blue = Math.round(dotColorRgb[2] + (dot.blue - dotColorRgb[2]) * dot.wave);
-
-        context.fillStyle = `rgb(${red}, ${green}, ${blue})`;
         context.globalAlpha = dot.alpha;
         context.beginPath();
         context.arc(dot.x, dot.y, dot.radius * dot.scale, 0, Math.PI * 2);
@@ -158,6 +156,10 @@
       });
 
       context.globalAlpha = 1;
+
+      if (waveActive) {
+        drawPhotoWave(wavePosition);
+      }
     };
 
     const stop = () => {

--- a/assets/scripts/profile-halftone.js
+++ b/assets/scripts/profile-halftone.js
@@ -13,7 +13,8 @@
   const WAVE_CYCLE_DURATION = WAVE_SWEEP_DURATION + WAVE_PAUSE_DURATION;
   const WAVE_BANDWIDTH = 0.068;
   const WAVE_MAX_SCALE = 2;
-  const COLOR_REVEAL_EXTENT = 2.5;
+  const PHOTO_DOT_THRESHOLD = 0.012;
+  const PHOTO_DOT_OUTLINE_WIDTH = 1;
 
   const drawHalftone = (portrait) => {
     const image = portrait.querySelector(".home-halftone__source");
@@ -31,10 +32,12 @@
     const sampleCanvas = document.createElement("canvas");
     const sampleContext = sampleCanvas.getContext("2d", { willReadFrequently: true });
     const context = canvas.getContext("2d");
+    const maskCanvas = document.createElement("canvas");
+    const maskContext = maskCanvas.getContext("2d");
     const waveCanvas = document.createElement("canvas");
     const waveContext = waveCanvas.getContext("2d");
 
-    if (!sampleContext || !context || !waveContext) {
+    if (!sampleContext || !context || !maskContext || !waveContext) {
       return;
     }
 
@@ -42,6 +45,8 @@
     canvas.height = height;
     sampleCanvas.width = width;
     sampleCanvas.height = height;
+    maskCanvas.width = width;
+    maskCanvas.height = height;
     waveCanvas.width = width;
     waveCanvas.height = height;
     sampleContext.drawImage(image, 0, 0, width, height);
@@ -79,6 +84,7 @@
           diagonal: (x * width + y * height) / diagonalLengthSquared,
           radius,
           scale: 1,
+          wave: 0,
           x,
           y
         });
@@ -93,37 +99,48 @@
     let isVisible = true;
     let lastFrameAt = 0;
 
-    const drawPhotoWave = (wavePosition) => {
-      const revealWidth = WAVE_BANDWIDTH * COLOR_REVEAL_EXTENT;
+    const drawPhotoDots = () => {
+      maskContext.clearRect(0, 0, width, height);
+      maskContext.fillStyle = "#ffffff";
+
+      dots.forEach((dot) => {
+        if (dot.wave < PHOTO_DOT_THRESHOLD) {
+          return;
+        }
+
+        maskContext.globalAlpha = dot.wave;
+        maskContext.beginPath();
+        maskContext.arc(dot.x, dot.y, dot.radius * dot.scale, 0, Math.PI * 2);
+        maskContext.fill();
+      });
+
+      maskContext.globalAlpha = 1;
 
       waveContext.clearRect(0, 0, width, height);
       waveContext.globalCompositeOperation = "source-over";
       waveContext.drawImage(sampleCanvas, 0, 0);
       waveContext.globalCompositeOperation = "destination-in";
-
-      const gradient = waveContext.createLinearGradient(
-        (wavePosition - revealWidth) * width,
-        (wavePosition - revealWidth) * height,
-        (wavePosition + revealWidth) * width,
-        (wavePosition + revealWidth) * height
-      );
-
-      gradient.addColorStop(0, "rgba(255, 255, 255, 0)");
-      gradient.addColorStop(0.1, "rgba(255, 255, 255, 0.05)");
-      gradient.addColorStop(0.2, "rgba(255, 255, 255, 0.25)");
-      gradient.addColorStop(0.3, "rgba(255, 255, 255, 0.66)");
-      gradient.addColorStop(0.4, "rgba(255, 255, 255, 0.96)");
-      gradient.addColorStop(0.5, "rgba(255, 255, 255, 1)");
-      gradient.addColorStop(0.6, "rgba(255, 255, 255, 0.96)");
-      gradient.addColorStop(0.7, "rgba(255, 255, 255, 0.66)");
-      gradient.addColorStop(0.8, "rgba(255, 255, 255, 0.25)");
-      gradient.addColorStop(0.9, "rgba(255, 255, 255, 0.05)");
-      gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
-
-      waveContext.fillStyle = gradient;
-      waveContext.fillRect(0, 0, width, height);
+      waveContext.drawImage(maskCanvas, 0, 0);
       waveContext.globalCompositeOperation = "source-over";
       context.drawImage(waveCanvas, 0, 0);
+
+      context.globalCompositeOperation = "destination-out";
+      context.strokeStyle = "#000000";
+      context.lineWidth = PHOTO_DOT_OUTLINE_WIDTH;
+
+      dots.forEach((dot) => {
+        if (dot.wave < PHOTO_DOT_THRESHOLD) {
+          return;
+        }
+
+        context.globalAlpha = dot.wave;
+        context.beginPath();
+        context.arc(dot.x, dot.y, dot.radius * dot.scale, 0, Math.PI * 2);
+        context.stroke();
+      });
+
+      context.globalCompositeOperation = "source-over";
+      context.globalAlpha = 1;
     };
 
     const drawFrame = (now, animate) => {
@@ -147,6 +164,7 @@
           : 0;
         const easedWave = wave * wave * (3 - 2 * wave);
 
+        dot.wave = easedWave;
         dot.scale = breath + (WAVE_MAX_SCALE - breath) * easedWave;
 
         context.globalAlpha = dot.alpha;
@@ -158,7 +176,7 @@
       context.globalAlpha = 1;
 
       if (waveActive) {
-        drawPhotoWave(wavePosition);
+        drawPhotoDots();
       }
     };
 

--- a/assets/stylesheets/site_styling.scss
+++ b/assets/stylesheets/site_styling.scss
@@ -266,7 +266,14 @@ body.home {
 }
 
 .home-hero__portrait {
+  // Experimental controls: hue-rotate(93deg) gives the current Matrix-green
+  // palette; roughly 125deg shifts the projection toward cyberpunk cyan.
+  --hologram-brightness: 1.08;
+  --hologram-contrast: 1.34;
+  --hologram-hue: 93deg;
+  --hologram-saturation: 6.5;
   align-self: end;
+  isolation: isolate;
   justify-self: center;
   mask-image: linear-gradient(to bottom, #000 0%, #000 90%, transparent 100%);
   max-width: 560px;
@@ -278,10 +285,117 @@ body.home {
   width: 100%;
 }
 
+.home-hologram {
+  align-items: end;
+  display: grid;
+  justify-items: center;
+  min-height: inherit;
+  perspective: 900px;
+  position: relative;
+  width: 100%;
+
+  &::before,
+  &::after {
+    content: "";
+    pointer-events: none;
+    position: absolute;
+  }
+
+  &::before {
+    animation: hologram-pixels 7s steps(2, end) infinite;
+    background:
+      radial-gradient(circle, rgba(#b9ffe6, 0.72) 0 1px, transparent 2px) 12% 37% / 37px 31px,
+      radial-gradient(circle, rgba(#58f5b5, 0.45) 0 1px, transparent 2px) 86% 22% / 51px 43px,
+      radial-gradient(circle, rgba(#b9ffe6, 0.48) 0 1px, transparent 2px) 65% 71% / 29px 47px;
+    inset: 5% 1% 13%;
+    opacity: 0.42;
+  }
+
+  &::after {
+    border: 1px solid rgba(#b9ffe6, 0.58);
+    border-radius: 50%;
+    bottom: 6%;
+    box-shadow:
+      0 0 12px rgba(#58f5b5, 0.58),
+      0 0 34px rgba(#0abf91, 0.36),
+      inset 0 0 18px rgba(#58f5b5, 0.22);
+    height: 4.5%;
+    width: 69%;
+    z-index: -1;
+  }
+}
+
+.home-hologram__beam {
+  background: linear-gradient(
+    to bottom,
+    rgba(#b9ffe6, 0.02),
+    rgba(#58f5b5, 0.08) 48%,
+    rgba(#0abf91, 0.25)
+  );
+  bottom: 7%;
+  clip-path: polygon(37% 0, 63% 0, 90% 100%, 10% 100%);
+  filter: blur(10px);
+  height: 88%;
+  opacity: 0.7;
+  pointer-events: none;
+  position: absolute;
+  width: 100%;
+  z-index: -2;
+}
+
+.home-hologram__figure {
+  display: grid;
+  grid-template-areas: "portrait";
+  justify-items: center;
+  position: relative;
+  transform: rotateY(-2deg);
+  width: fit-content;
+
+  &::before,
+  &::after {
+    content: "";
+    grid-area: portrait;
+    inset: 0;
+    mask-image: var(--hologram-mask);
+    mask-position: center;
+    mask-repeat: no-repeat;
+    mask-size: 100% 100%;
+    pointer-events: none;
+    position: absolute;
+    -webkit-mask-image: var(--hologram-mask);
+    -webkit-mask-position: center;
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-size: 100% 100%;
+  }
+
+  &::before {
+    background: repeating-linear-gradient(
+      to bottom,
+      rgba(#d9fff0, 0.58) 0,
+      rgba(#d9fff0, 0.58) 1px,
+      transparent 1px,
+      transparent 6px
+    );
+    mix-blend-mode: overlay;
+    opacity: 0.64;
+    z-index: 4;
+  }
+
+  &::after {
+    background-image:
+      linear-gradient(90deg, transparent 48%, rgba(#b9ffe6, 0.32) 50%, transparent 52%),
+      linear-gradient(transparent 48%, rgba(#58f5b5, 0.28) 50%, transparent 52%);
+    background-size: 15px 100%, 100% 15px;
+    mix-blend-mode: screen;
+    opacity: 0.18;
+    z-index: 5;
+  }
+}
+
 .home-hero__portrait-image {
-  display: block;
   aspect-ratio: 2481 / 3508;
-  filter: drop-shadow(5px 17px 27px rgba(#011f29, 0.27));
+  display: block;
+  grid-area: portrait;
   height: auto;
   margin: 0 auto;
   max-height: 710px;
@@ -289,6 +403,126 @@ body.home {
   object-fit: contain;
   position: relative;
   width: auto;
+}
+
+.home-hologram__image {
+  filter:
+    grayscale(1)
+    sepia(1)
+    saturate(var(--hologram-saturation))
+    hue-rotate(var(--hologram-hue))
+    brightness(var(--hologram-brightness))
+    contrast(var(--hologram-contrast))
+    drop-shadow(0 0 6px rgba(#b9ffe6, 0.34))
+    drop-shadow(0 0 22px rgba(#0abf91, 0.25));
+}
+
+.home-hologram__image--core {
+  animation: hologram-flicker 6s linear infinite;
+  opacity: 0.91;
+  z-index: 1;
+}
+
+.home-hologram__image--echo-a,
+.home-hologram__image--echo-b {
+  mix-blend-mode: screen;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.home-hologram__image--echo-a {
+  animation: hologram-glitch-a 8s steps(1, end) infinite;
+  clip-path: inset(15% 0 63% 0);
+  opacity: 0.38;
+}
+
+.home-hologram__image--echo-b {
+  animation: hologram-glitch-b 11s steps(1, end) infinite;
+  clip-path: inset(54% 0 26% 0);
+  filter:
+    grayscale(1)
+    sepia(1)
+    saturate(7)
+    hue-rotate(var(--hologram-hue))
+    brightness(1.35)
+    contrast(1.55)
+    drop-shadow(0 0 7px rgba(#b9ffe6, 0.58));
+  opacity: 0.27;
+}
+
+.home-hologram__scan {
+  animation: hologram-scan 5.5s ease-in-out infinite;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    rgba(#d9fff0, 0.76) 46%,
+    rgba(#58f5b5, 0.35) 54%,
+    transparent
+  );
+  height: 14%;
+  left: 0;
+  mask-image: var(--hologram-mask);
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: 100% 715%;
+  mix-blend-mode: screen;
+  opacity: 0.58;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 6;
+  -webkit-mask-image: var(--hologram-mask);
+  -webkit-mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: 100% 715%;
+}
+
+.home-hologram__emitter {
+  background: radial-gradient(ellipse, rgba(#b9ffe6, 0.62), rgba(#58f5b5, 0.12) 46%, transparent 72%);
+  border-radius: 50%;
+  border-top: 1px solid rgba(#d9fff0, 0.68);
+  bottom: 5.8%;
+  box-shadow: 0 -5px 22px rgba(#58f5b5, 0.28);
+  height: 5%;
+  opacity: 0.58;
+  pointer-events: none;
+  position: absolute;
+  width: 57%;
+  z-index: 7;
+}
+
+@keyframes hologram-flicker {
+  0%, 8%, 12%, 48%, 52%, 79%, 82%, 100% { opacity: 0.91; }
+  10%, 50%, 80% { opacity: 0.76; }
+  11%, 51%, 81% { opacity: 0.98; }
+}
+
+@keyframes hologram-glitch-a {
+  0%, 72%, 76%, 100% { clip-path: inset(15% 0 63% 0); transform: translateX(0); }
+  73% { clip-path: inset(24% 0 58% 0); transform: translateX(-10px); }
+  74% { clip-path: inset(43% 0 39% 0); transform: translateX(8px); }
+  75% { clip-path: inset(8% 0 79% 0); transform: translateX(-4px); }
+}
+
+@keyframes hologram-glitch-b {
+  0%, 46%, 50%, 100% { clip-path: inset(54% 0 26% 0); transform: translateX(0); }
+  47% { clip-path: inset(68% 0 17% 0); transform: translateX(11px); }
+  48% { clip-path: inset(31% 0 55% 0); transform: translateX(-7px); }
+  49% { clip-path: inset(82% 0 7% 0); transform: translateX(5px); }
+}
+
+@keyframes hologram-scan {
+  0% { opacity: 0; transform: translateY(-10%); }
+  12% { opacity: 0.58; }
+  82% { opacity: 0.46; }
+  100% { opacity: 0; transform: translateY(620%); }
+}
+
+@keyframes hologram-pixels {
+  0%, 100% { opacity: 0.25; transform: translateY(0); }
+  35% { opacity: 0.5; transform: translateY(-3px); }
+  67% { opacity: 0.34; transform: translate(2px, 2px); }
 }
 
 @media screen and (max-width: 48em) {
@@ -321,6 +555,29 @@ body.home {
     max-height: none;
     max-width: 430px;
     width: 100%;
+  }
+
+  .home-hologram::after {
+    bottom: 4%;
+  }
+
+  .home-hologram__emitter {
+    bottom: 3.8%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-hologram::before,
+  .home-hologram__image--core,
+  .home-hologram__image--echo-a,
+  .home-hologram__image--echo-b,
+  .home-hologram__scan {
+    animation: none;
+  }
+
+  .home-hologram__scan {
+    opacity: 0.24;
+    top: 43%;
   }
 }
 

--- a/assets/stylesheets/site_styling.scss
+++ b/assets/stylesheets/site_styling.scss
@@ -266,14 +266,7 @@ body.home {
 }
 
 .home-hero__portrait {
-  // Experimental controls: hue-rotate(93deg) gives the current Matrix-green
-  // palette; roughly 125deg shifts the projection toward cyberpunk cyan.
-  --hologram-brightness: 1.08;
-  --hologram-contrast: 1.34;
-  --hologram-hue: 93deg;
-  --hologram-saturation: 6.5;
   align-self: end;
-  isolation: isolate;
   justify-self: center;
   mask-image: linear-gradient(to bottom, #000 0%, #000 90%, transparent 100%);
   max-width: 560px;
@@ -285,111 +278,12 @@ body.home {
   width: 100%;
 }
 
-.home-hologram {
-  align-items: end;
-  display: grid;
-  justify-items: center;
-  min-height: inherit;
-  perspective: 900px;
-  position: relative;
-  width: 100%;
-
-  &::before,
-  &::after {
-    content: "";
-    pointer-events: none;
-    position: absolute;
-  }
-
-  &::before {
-    animation: hologram-pixels 7s steps(2, end) infinite;
-    background:
-      radial-gradient(circle, rgba(#b9ffe6, 0.72) 0 1px, transparent 2px) 12% 37% / 37px 31px,
-      radial-gradient(circle, rgba(#58f5b5, 0.45) 0 1px, transparent 2px) 86% 22% / 51px 43px,
-      radial-gradient(circle, rgba(#b9ffe6, 0.48) 0 1px, transparent 2px) 65% 71% / 29px 47px;
-    inset: 5% 1% 13%;
-    opacity: 0.42;
-  }
-
-  &::after {
-    border: 1px solid rgba(#b9ffe6, 0.58);
-    border-radius: 50%;
-    bottom: 6%;
-    box-shadow:
-      0 0 12px rgba(#58f5b5, 0.58),
-      0 0 34px rgba(#0abf91, 0.36),
-      inset 0 0 18px rgba(#58f5b5, 0.22);
-    height: 4.5%;
-    width: 69%;
-    z-index: -1;
-  }
-}
-
-.home-hologram__beam {
-  background: linear-gradient(
-    to bottom,
-    rgba(#b9ffe6, 0.02),
-    rgba(#58f5b5, 0.08) 48%,
-    rgba(#0abf91, 0.25)
-  );
-  bottom: 7%;
-  clip-path: polygon(37% 0, 63% 0, 90% 100%, 10% 100%);
-  filter: blur(10px);
-  height: 88%;
-  opacity: 0.7;
-  pointer-events: none;
-  position: absolute;
-  width: 100%;
-  z-index: -2;
-}
-
-.home-hologram__figure {
+.home-halftone {
   display: grid;
   grid-template-areas: "portrait";
   justify-items: center;
   position: relative;
-  transform: rotateY(-2deg);
   width: fit-content;
-
-  &::before,
-  &::after {
-    content: "";
-    grid-area: portrait;
-    inset: 0;
-    mask-image: var(--hologram-mask);
-    mask-position: center;
-    mask-repeat: no-repeat;
-    mask-size: 100% 100%;
-    pointer-events: none;
-    position: absolute;
-    -webkit-mask-image: var(--hologram-mask);
-    -webkit-mask-position: center;
-    -webkit-mask-repeat: no-repeat;
-    -webkit-mask-size: 100% 100%;
-  }
-
-  &::before {
-    background: repeating-linear-gradient(
-      to bottom,
-      rgba(#d9fff0, 0.58) 0,
-      rgba(#d9fff0, 0.58) 1px,
-      transparent 1px,
-      transparent 6px
-    );
-    mix-blend-mode: overlay;
-    opacity: 0.64;
-    z-index: 4;
-  }
-
-  &::after {
-    background-image:
-      linear-gradient(90deg, transparent 48%, rgba(#b9ffe6, 0.32) 50%, transparent 52%),
-      linear-gradient(transparent 48%, rgba(#58f5b5, 0.28) 50%, transparent 52%);
-    background-size: 15px 100%, 100% 15px;
-    mix-blend-mode: screen;
-    opacity: 0.18;
-    z-index: 5;
-  }
 }
 
 .home-hero__portrait-image {
@@ -405,124 +299,33 @@ body.home {
   width: auto;
 }
 
-.home-hologram__image {
-  filter:
-    grayscale(1)
-    sepia(1)
-    saturate(var(--hologram-saturation))
-    hue-rotate(var(--hologram-hue))
-    brightness(var(--hologram-brightness))
-    contrast(var(--hologram-contrast))
-    drop-shadow(0 0 6px rgba(#b9ffe6, 0.34))
-    drop-shadow(0 0 22px rgba(#0abf91, 0.25));
+.home-halftone__source,
+.home-halftone__canvas {
+  grid-area: portrait;
 }
 
-.home-hologram__image--core {
-  animation: hologram-flicker 6s linear infinite;
-  opacity: 0.91;
-  z-index: 1;
+.home-halftone__source {
+  filter: saturate(0.75) contrast(1.03);
 }
 
-.home-hologram__image--echo-a,
-.home-hologram__image--echo-b {
-  mix-blend-mode: screen;
-  pointer-events: none;
-  z-index: 2;
-}
-
-.home-hologram__image--echo-a {
-  animation: hologram-glitch-a 8s steps(1, end) infinite;
-  clip-path: inset(15% 0 63% 0);
-  opacity: 0.38;
-}
-
-.home-hologram__image--echo-b {
-  animation: hologram-glitch-b 11s steps(1, end) infinite;
-  clip-path: inset(54% 0 26% 0);
-  filter:
-    grayscale(1)
-    sepia(1)
-    saturate(7)
-    hue-rotate(var(--hologram-hue))
-    brightness(1.35)
-    contrast(1.55)
-    drop-shadow(0 0 7px rgba(#b9ffe6, 0.58));
-  opacity: 0.27;
-}
-
-.home-hologram__scan {
-  animation: hologram-scan 5.5s ease-in-out infinite;
-  background: linear-gradient(
-    to bottom,
-    transparent,
-    rgba(#d9fff0, 0.76) 46%,
-    rgba(#58f5b5, 0.35) 54%,
-    transparent
-  );
-  height: 14%;
-  left: 0;
-  mask-image: var(--hologram-mask);
-  mask-position: center;
-  mask-repeat: no-repeat;
-  mask-size: 100% 715%;
-  mix-blend-mode: screen;
-  opacity: 0.58;
+.home-halftone__canvas {
+  filter: drop-shadow(5px 17px 27px rgba(#011f29, 0.3));
+  height: 100%;
+  inset: 0;
+  opacity: 0;
   pointer-events: none;
   position: absolute;
-  top: 0;
   width: 100%;
-  z-index: 6;
-  -webkit-mask-image: var(--hologram-mask);
-  -webkit-mask-position: center;
-  -webkit-mask-repeat: no-repeat;
-  -webkit-mask-size: 100% 715%;
 }
 
-.home-hologram__emitter {
-  background: radial-gradient(ellipse, rgba(#b9ffe6, 0.62), rgba(#58f5b5, 0.12) 46%, transparent 72%);
-  border-radius: 50%;
-  border-top: 1px solid rgba(#d9fff0, 0.68);
-  bottom: 5.8%;
-  box-shadow: 0 -5px 22px rgba(#58f5b5, 0.28);
-  height: 5%;
-  opacity: 0.58;
-  pointer-events: none;
-  position: absolute;
-  width: 57%;
-  z-index: 7;
-}
+.home-halftone.is-rendered {
+  .home-halftone__source {
+    opacity: 0;
+  }
 
-@keyframes hologram-flicker {
-  0%, 8%, 12%, 48%, 52%, 79%, 82%, 100% { opacity: 0.91; }
-  10%, 50%, 80% { opacity: 0.76; }
-  11%, 51%, 81% { opacity: 0.98; }
-}
-
-@keyframes hologram-glitch-a {
-  0%, 72%, 76%, 100% { clip-path: inset(15% 0 63% 0); transform: translateX(0); }
-  73% { clip-path: inset(24% 0 58% 0); transform: translateX(-10px); }
-  74% { clip-path: inset(43% 0 39% 0); transform: translateX(8px); }
-  75% { clip-path: inset(8% 0 79% 0); transform: translateX(-4px); }
-}
-
-@keyframes hologram-glitch-b {
-  0%, 46%, 50%, 100% { clip-path: inset(54% 0 26% 0); transform: translateX(0); }
-  47% { clip-path: inset(68% 0 17% 0); transform: translateX(11px); }
-  48% { clip-path: inset(31% 0 55% 0); transform: translateX(-7px); }
-  49% { clip-path: inset(82% 0 7% 0); transform: translateX(5px); }
-}
-
-@keyframes hologram-scan {
-  0% { opacity: 0; transform: translateY(-10%); }
-  12% { opacity: 0.58; }
-  82% { opacity: 0.46; }
-  100% { opacity: 0; transform: translateY(620%); }
-}
-
-@keyframes hologram-pixels {
-  0%, 100% { opacity: 0.25; transform: translateY(0); }
-  35% { opacity: 0.5; transform: translateY(-3px); }
-  67% { opacity: 0.34; transform: translate(2px, 2px); }
+  .home-halftone__canvas {
+    opacity: 1;
+  }
 }
 
 @media screen and (max-width: 48em) {
@@ -557,27 +360,8 @@ body.home {
     width: 100%;
   }
 
-  .home-hologram::after {
-    bottom: 4%;
-  }
-
-  .home-hologram__emitter {
-    bottom: 3.8%;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .home-hologram::before,
-  .home-hologram__image--core,
-  .home-hologram__image--echo-a,
-  .home-hologram__image--echo-b,
-  .home-hologram__scan {
-    animation: none;
-  }
-
-  .home-hologram__scan {
-    opacity: 0.24;
-    top: 43%;
+  .home-halftone {
+    width: 100%;
   }
 }
 

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -10,15 +10,9 @@
     </section>
     <div class="home-hero__portrait">
       {{- with resources.Get "images/profile-nobg.webp" -}}
-        <div class="home-hologram" style="--hologram-mask: url('{{ .RelPermalink }}');">
-          <span class="home-hologram__beam" aria-hidden="true"></span>
-          <div class="home-hologram__figure">
-            <img src="{{ .RelPermalink }}" class="home-hero__portrait-image home-hologram__image home-hologram__image--core" alt="Portrait of Winthrop Gillis">
-            <img src="{{ .RelPermalink }}" class="home-hero__portrait-image home-hologram__image home-hologram__image--echo-a" alt="" aria-hidden="true">
-            <img src="{{ .RelPermalink }}" class="home-hero__portrait-image home-hologram__image home-hologram__image--echo-b" alt="" aria-hidden="true">
-            <span class="home-hologram__scan" aria-hidden="true"></span>
-          </div>
-          <span class="home-hologram__emitter" aria-hidden="true"></span>
+        <div class="home-halftone" data-halftone-portrait data-dot-color="#55cbd3">
+          <img src="{{ .RelPermalink }}" class="home-hero__portrait-image home-halftone__source" alt="Portrait of Winthrop Gillis">
+          <canvas class="home-halftone__canvas" aria-hidden="true"></canvas>
         </div>
       {{- end -}}
     </div>

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -10,7 +10,16 @@
     </section>
     <div class="home-hero__portrait">
       {{- with resources.Get "images/profile-nobg.webp" -}}
-        <img src="{{ .RelPermalink }}" class="home-hero__portrait-image" alt="Portrait of Winthrop Gillis">
+        <div class="home-hologram" style="--hologram-mask: url('{{ .RelPermalink }}');">
+          <span class="home-hologram__beam" aria-hidden="true"></span>
+          <div class="home-hologram__figure">
+            <img src="{{ .RelPermalink }}" class="home-hero__portrait-image home-hologram__image home-hologram__image--core" alt="Portrait of Winthrop Gillis">
+            <img src="{{ .RelPermalink }}" class="home-hero__portrait-image home-hologram__image home-hologram__image--echo-a" alt="" aria-hidden="true">
+            <img src="{{ .RelPermalink }}" class="home-hero__portrait-image home-hologram__image home-hologram__image--echo-b" alt="" aria-hidden="true">
+            <span class="home-hologram__scan" aria-hidden="true"></span>
+          </div>
+          <span class="home-hologram__emitter" aria-hidden="true"></span>
+        </div>
       {{- end -}}
     </div>
   </div>

--- a/layouts/partials/javascripts.html
+++ b/layouts/partials/javascripts.html
@@ -13,3 +13,9 @@
     im.style.paddingBottom = Math.round(Math.random() * 29 + 18) + 'px';
   });
 </script>
+
+{{- if .IsHome -}}
+  {{- with resources.Get "scripts/profile-halftone.js" | resources.Minify -}}
+<script defer src="{{ .RelPermalink }}"></script>
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
## Summary
- replace the homepage portrait with a canvas-rendered cyan halftone treatment
- animate a slow diagonal wave that enlarges the dots and reveals full-resolution image detail inside each circle
- preserve background-colored dot boundaries, an eight-second pause between waves, reduced-motion behavior, and offscreen pausing
- retain the original portrait as a fallback

## Validation
- node --check assets/scripts/profile-halftone.js
- hugo --minify --destination /tmp/wingillis-photo-dot-final
- browser-verified at desktop and mobile widths with no overflow or console warnings