### PR TITLE
Unify site styling and refine halftone animation

### DIFF
--- a/assets/scripts/profile-halftone.js
+++ b/assets/scripts/profile-halftone.js
@@ -12,7 +12,7 @@
   const WAVE_PAUSE_DURATION = 8000;
   const WAVE_CYCLE_DURATION = WAVE_SWEEP_DURATION + WAVE_PAUSE_DURATION;
   const WAVE_BANDWIDTH = 0.068;
-  const WAVE_MAX_SCALE = 2;
+  const DOT_RADIUS_MAX = DOT_SPACING / 2;
   const PHOTO_DOT_THRESHOLD = 0.012;
   const PHOTO_DOT_OUTLINE_WIDTH = 1;
 
@@ -83,7 +83,7 @@
           alpha: alpha * (0.62 + tone * 0.38),
           diagonal: (x * width + y * height) / diagonalLengthSquared,
           radius,
-          scale: 1,
+          renderedRadius: radius,
           wave: 0,
           x,
           y
@@ -110,7 +110,7 @@
 
         maskContext.globalAlpha = dot.wave;
         maskContext.beginPath();
-        maskContext.arc(dot.x, dot.y, dot.radius * dot.scale, 0, Math.PI * 2);
+        maskContext.arc(dot.x, dot.y, dot.renderedRadius, 0, Math.PI * 2);
         maskContext.fill();
       });
 
@@ -135,7 +135,7 @@
 
         context.globalAlpha = dot.wave;
         context.beginPath();
-        context.arc(dot.x, dot.y, dot.radius * dot.scale, 0, Math.PI * 2);
+        context.arc(dot.x, dot.y, dot.renderedRadius, 0, Math.PI * 2);
         context.stroke();
       });
 
@@ -163,13 +163,17 @@
           ? Math.exp(-0.5 * Math.pow(distance / WAVE_BANDWIDTH, 2))
           : 0;
         const easedWave = wave * wave * (3 - 2 * wave);
+        const restingRadius = dot.radius * breath;
 
         dot.wave = easedWave;
-        dot.scale = breath + (WAVE_MAX_SCALE - breath) * easedWave;
+        dot.renderedRadius = Math.min(
+          DOT_RADIUS_MAX,
+          restingRadius + (DOT_RADIUS_MAX - restingRadius) * easedWave
+        );
 
         context.globalAlpha = dot.alpha;
         context.beginPath();
-        context.arc(dot.x, dot.y, dot.radius * dot.scale, 0, Math.PI * 2);
+        context.arc(dot.x, dot.y, dot.renderedRadius, 0, Math.PI * 2);
         context.fill();
       });
 

--- a/assets/stylesheets/_base.scss
+++ b/assets/stylesheets/_base.scss
@@ -1,8 +1,9 @@
 
 $background-color: #082f36;
-$text-color: #e9f5ef;
+$text-color: #f5faf8;
 $caption-color: #adc4bd;
-$link-color: #b8d894;
+$link-color: #d8f8dc;
+$visited-link-color: #c7efce;
 $menu-link-hover: rgba(#FFFFFF, 0.13);
 $code-background: rgba(#78ae98, 0.24);
 

--- a/assets/stylesheets/navbar.scss
+++ b/assets/stylesheets/navbar.scss
@@ -6,7 +6,7 @@
 }
 
 .header {
-  background-color: rgba(#052d35, 0.78);
+  background-color: rgba(#052d35, 0.64);
   border-bottom: 1px solid rgba(#d1e6db, 0.11);
 }
 
@@ -33,8 +33,8 @@ a.pure-menu-heading.pure-menu-link {
   color: #f4fbf7;
 }
 
-a.pure-menu-link {
-  color: #d9eee4;
+nav a.pure-menu-link {
+  color: #f4fbf7;
   padding-bottom: 18px;
   padding-top: 18px;
   transition: background-color 0.2s;

--- a/assets/stylesheets/site_styling.scss
+++ b/assets/stylesheets/site_styling.scss
@@ -41,12 +41,12 @@ a:link {
 }
 
 a:visited {
-  color: $link-color;
+  color: $visited-link-color;
   // text-decoration: none;
 }
 
 a:hover {
-  color: lighten($link-color, 20%);
+  color: #ffffff;
   text-decoration: none;
 }
 
@@ -59,13 +59,13 @@ a.pure-menu-link:hover {
 }
 
 .button-success {
-  background: #b8d894;
-  color: #082f36;
+  background: #d5f1d4;
+  color: #0a4b50;
   transition: background 0.2s;
 }
 
 .button-success:hover {
-  background: #d7eab9;
+  background: #ffffff;
 }
 
 code {
@@ -77,77 +77,42 @@ code {
 }
 
 body {
-  background-color: $background-color;
-  background-image:
-    radial-gradient(circle at 11% 12%, rgba(#7e955d, 0.12), transparent 32rem),
-    radial-gradient(circle at 72% 40%, rgba(#23777d, 0.16), transparent 30rem),
-    radial-gradient(circle at 86% 86%, rgba(#a36f3b, 0.035), transparent 24rem),
-    linear-gradient(132deg, #10474a 0%, #0a414b 43%, #062f3c 100%);
-  background-attachment: fixed;
-  background-position: center;
+  background: $background-color;
   color: $text-color;
+  min-height: 100vh;
+  overflow-x: hidden;
   font-weight: 300;
   font-family: 'Roboto', sans-serif;
 }
 
-// Home page: a calm, matte field that picks up the teal and green tones in the
-// portrait without turning the rest of the site into a themed landing page.
-body.home {
-  background: #082f36;
-  color: #f5faf8;
-  min-height: 100vh;
-  overflow-x: hidden;
+body::before,
+body::after {
+  content: "";
+  inset: 0;
+  pointer-events: none;
+  position: fixed;
+}
 
-  &::before,
-  &::after {
-    content: "";
-    inset: 0;
-    pointer-events: none;
-    position: fixed;
-  }
+body::before {
+  background:
+    radial-gradient(circle at 11% 12%, rgba(#7e955d, 0.15), transparent 32rem),
+    radial-gradient(circle at 72% 40%, rgba(#23777d, 0.19), transparent 30rem),
+    radial-gradient(circle at 86% 86%, rgba(#a36f3b, 0.045), transparent 24rem),
+    radial-gradient(circle at 73% 8%, rgba(#5d9d8e, 0.08), transparent 26rem),
+    linear-gradient(132deg, #10474a 0%, #0a414b 43%, #062f3c 100%);
+  z-index: -2;
+}
 
-  &::before {
-    background:
-      radial-gradient(circle at 11% 12%, rgba(#7e955d, 0.15), transparent 32rem),
-      radial-gradient(circle at 72% 40%, rgba(#23777d, 0.19), transparent 30rem),
-      radial-gradient(circle at 86% 86%, rgba(#a36f3b, 0.045), transparent 24rem),
-      radial-gradient(circle at 73% 8%, rgba(#5d9d8e, 0.08), transparent 26rem),
-      linear-gradient(132deg, #10474a 0%, #0a414b 43%, #062f3c 100%);
-    z-index: -2;
-  }
+body::after {
+  background-image: radial-gradient(rgba(#dbeee3, 0.12) 0.7px, transparent 0.8px);
+  background-size: 5px 5px;
+  opacity: 0.08;
+  z-index: -1;
+}
 
-  &::after {
-    background-image: radial-gradient(rgba(#dbeee3, 0.12) 0.7px, transparent 0.8px);
-    background-size: 5px 5px;
-    opacity: 0.08;
-    z-index: -1;
-  }
-
-  .header {
-    background-color: rgba(#052d35, 0.64);
-    border-bottom: 1px solid rgba(#d1e6db, 0.11);
-  }
-
-  a.pure-menu-heading.pure-menu-link,
-  .pure-menu-link,
-  .pure-menu-item span {
-    color: #f4fbf7;
-  }
-
-  nav ul.pure-menu-children {
-    background-color: #083842;
-  }
-
-  a.pure-menu-link:hover {
-    color: #ffffff;
-    background-color: rgba(#d4eee2, 0.09);
-  }
-
-  #svg-social-icons {
-    position: relative;
-    z-index: 1;
-  }
-
+#svg-social-icons {
+  position: relative;
+  z-index: 1;
 }
 
 .home-hero {
@@ -159,18 +124,6 @@ body.home {
   min-height: calc(100vh - 161px);
   padding: 28px 30px 45px;
   position: relative;
-}
-
-.home-hero::after {
-  background-image: radial-gradient(rgba(#e4fff2, 0.75) 0.55px, transparent 0.65px);
-  background-size: 4px 4px;
-  content: "";
-  inset: 0;
-  mix-blend-mode: soft-light;
-  opacity: 0.17;
-  pointer-events: none;
-  position: absolute;
-  z-index: 2;
 }
 
 .home-hero__content {
@@ -185,16 +138,6 @@ body.home {
   max-width: 580px;
   position: relative;
   z-index: 1;
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  p,
-  li {
-    color: #f5faf8;
-  }
 
   h1 {
     font-size: clamp(2.65rem, 6vw, 4.6rem);
@@ -213,12 +156,8 @@ body.home {
     padding: 0;
   }
 
-  a {
-    color: #d8f8dc;
-  }
-
-  a:hover {
-    color: #ffffff;
+  a:visited {
+    color: $visited-link-color;
   }
 
   strong,
@@ -492,12 +431,6 @@ div.icon, span.icon {
   padding-top: 10px;
 }
 
-p {
-  b {
-    color: darken($text-color, 13%);
-  }
-}
-
 figure {
   padding: 11px;
   @media screen and (min-width: 30em) {
@@ -558,6 +491,7 @@ figcaption {
 
 
 b, strong {
+  color: #ffffff;
   font-weight: bold;
 }
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
   <head>
     {{ partial "head.html" . }}
   </head>
-  <body{{ if .IsHome }} class="home"{{ end }}>
+  <body>
     {{ partial "navbar.html" }}
     {{ partial "social_header.html" . }}
     {{- block "main" . -}}


### PR DESCRIPTION
## Summary
- unify the shared site theme and simplify home-page styling
- update navigation and base layout details to match the refreshed theme
- cap the halftone resolution wave at the dot-grid boundary
- expand every wave dot toward the same maximum size while preserving background-colored outlines

## Verification
- node --check assets/scripts/profile-halftone.js
- hugo --minify --destination /tmp/wingillis-halftone-build
- browser-tested the animated canvas with no console errors