### PR TITLE
Prevent profile photo flash before halftone

### DIFF
--- a/assets/scripts/profile-halftone.js
+++ b/assets/scripts/profile-halftone.js
@@ -26,7 +26,7 @@
     const canvas = portrait.querySelector(".home-halftone__canvas");
 
     if (!image || !canvas || !image.naturalWidth || !image.naturalHeight) {
-      return;
+      return false;
     }
 
     const renderedWidth = image.getBoundingClientRect().width;
@@ -45,7 +45,7 @@
     const waveContext = waveCanvas.getContext("2d");
 
     if (!sampleContext || !context || !baseContext || !maskContext || !waveContext) {
-      return;
+      return false;
     }
 
     canvas.width = width;
@@ -511,11 +511,15 @@
     }
 
     start();
+    return true;
   };
 
   document.querySelectorAll("[data-halftone-portrait]").forEach((portrait) => {
     const image = portrait.querySelector(".home-halftone__source");
     const compactViewport = window.matchMedia("(max-width: 48em)");
+    const showFallback = () => {
+      portrait.classList.add("is-fallback");
+    };
 
     const initialize = () => {
       if (
@@ -527,8 +531,17 @@
         return;
       }
 
-      portrait.dataset.halftoneInitialized = "true";
-      drawHalftone(portrait, compactViewport);
+      try {
+        if (!drawHalftone(portrait, compactViewport)) {
+          showFallback();
+          return;
+        }
+
+        portrait.classList.remove("is-fallback");
+        portrait.dataset.halftoneInitialized = "true";
+      } catch {
+        showFallback();
+      }
     };
 
     if (!image) {

--- a/assets/stylesheets/site_styling.scss
+++ b/assets/stylesheets/site_styling.scss
@@ -308,6 +308,10 @@ body::after {
   filter: saturate(0.75) contrast(1.03);
 }
 
+html.js .home-halftone__source {
+  opacity: 0;
+}
+
 .home-halftone__canvas {
   filter: drop-shadow(5px 17px 27px rgba(#011f29, 0.3));
   height: 100%;
@@ -326,6 +330,10 @@ body::after {
   .home-halftone__canvas {
     opacity: 1;
   }
+}
+
+html.js .home-halftone.is-fallback .home-halftone__source {
+  opacity: 1;
 }
 
 @media screen and (max-width: 58em) {
@@ -412,6 +420,10 @@ body::after {
       contrast(1.03)
       brightness(0.96)
       drop-shadow(0 8px 8px rgba(#011f29, 0.28));
+  }
+
+  html.js .home-halftone__source {
+    opacity: 1;
   }
 
   .home-halftone__canvas {

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -35,8 +35,17 @@
     </section>
     <div class="home-hero__portrait">
       {{- with resources.Get "images/profile-nobg.webp" -}}
+        {{- $portrait := .Resize "960x webp q82" -}}
         <div class="home-halftone" data-halftone-portrait data-dot-color="#55cbd3">
-          <img src="{{ .RelPermalink }}" class="home-hero__portrait-image home-halftone__source" alt="Portrait of Winthrop Gillis">
+          <img
+            src="{{ $portrait.RelPermalink }}"
+            width="{{ $portrait.Width }}"
+            height="{{ $portrait.Height }}"
+            class="home-hero__portrait-image home-halftone__source"
+            alt="Portrait of Winthrop Gillis"
+            decoding="async"
+            fetchpriority="high"
+            loading="eager">
           <canvas class="home-halftone__canvas" aria-hidden="true"></canvas>
         </div>
       {{- end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,6 @@
 <title>{{ .Site.Title }} | {{ .Params.Title }}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<script>document.documentElement.classList.add("js");</script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/pure-min.css" integrity="sha384-X38yfunGUhNzHpBaEBsWLO+A0HDYOQi8ufWDkZ0k9e0eXz/tH3II7uKZ9msv++Ls" crossorigin="anonymous">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="96x96" href="/favicon/favicon-96x96.png">


### PR DESCRIPTION
## Summary
- hide the raw desktop portrait before the first halftone frame is ready
- preserve photo fallbacks for no-JavaScript and canvas failure cases
- resize and prioritize the hero image, reducing its payload from about 1.1 MB to about 112 KB
- retain the existing compact/mobile portrait treatment

## Verification
- Hugo production build
- JavaScript syntax check
- desktop and mobile browser previews
- no browser warnings or errors